### PR TITLE
Update `criterion` due to `serde-cbor` no longer being maintained.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bitvec = "0.17.3"
 fnv = "1.0.6"
 
 [dev-dependencies]
-criterion = "0.3.3"
+criterion = "0.4.0"
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0127